### PR TITLE
Feature / add install availability detection and fallback messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Change Log
 
 ...
@@ -7,3 +9,10 @@
 ### Added
 
 - French translation support by [@BesrourMS](https://github.com/BesrourMS) in https://github.com/ryxxn/pwa-install-prompt/pull/2
+
+## [0.2.0] - 2025-05-14
+
+### Added
+
+- Added `installAvailable` logic to determine PWA installability
+- New fallback messages when installation is unavailable (`INSTALL_UNAVAILABLE`, `INSTALL_SKIP_BUTTON`)

--- a/en/index.js
+++ b/en/index.js
@@ -219,11 +219,11 @@ function main() {
   }
   else if (!isIOS) {
     let beforeInstallPromptFired = false;
+    const installButton = document.getElementById('wepp-install-button');
 
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
-      const installButton = document.getElementById('wepp-install-button');
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
@@ -231,12 +231,13 @@ function main() {
       beforeInstallPromptFired = true;
     });
 
-
-    if (!beforeInstallPromptFired) {
-      const installButton = document.getElementById('wepp-install-button');
-      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
-      installButton.disabled = true;
-    }
+    // Give the browser time to fire the beforeinstallprompt event
+    setTimeout(() => {
+      if (!beforeInstallPromptFired) {
+        installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+        installButton.disabled = true;
+      }
+    }, 1000); // 1 second delay
   }
 
   window.addEventListener('appinstalled', () => {

--- a/en/index.js
+++ b/en/index.js
@@ -17,6 +17,7 @@ const TEXT = {
   WAITING: 'Loading app info...', // Loading app info...
   SKIP_BUTTON: "I'm fine, I'll just view it on my mobile.", // I'm fine, I'll just view it on my mobile.
   INSTALL_BUTTON: 'Install as an app', // Install as an app
+  INSTALL_UNAVAILABLE: "The app is already installed or your environment doesn't support installation.", // The app is already installed or your environment doesn't support installation.
   // IOS device specific text
   IOS: {
     TITLE: 'IOS App Installation Method', // IOS App Installation Method
@@ -118,40 +119,6 @@ function appendStyles() {
   document.head.appendChild(style);
 }
 
-/**
- * Create a Proxy object to detect whether PWA is installed
- */
-function createProxy() {
-  // 상태 객체
-  let state = {
-    isInstalled: true,
-  };
-
-  // Handlers for detecting state changes
-  const handler = {
-    set: function (target, property, value) {
-      // console.log(
-      //   `${property} changed from ${target[property]} to ${value}.`
-      // );
-      target[property] = value;
-      // Additional actions after status change
-      if (property === 'isInstalled') {
-        if (value) {
-          // console.log('PWA is already installed');
-        } else {
-          // console.log('PWA is not installed');
-        }
-      }
-      return true;
-    },
-  };
-
-  // Proxy
-  const proxyState = new Proxy(state, handler);
-
-  return proxyState;
-}
-
 const getModalContent = (isIOS) => {
   return isIOS ? IOS_MODAL_CONTENT : DEFAULT_MODAL_CONTENT;
 };
@@ -226,6 +193,9 @@ const showPrompt = (deferredPrompt) => {
 
 function main() {
   const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const isRunningAsPWA =
+    window.matchMedia('(display-mode: standalone)').matches
+    || window.navigator.standalone === true; // iOS
 
   appendStyles();
 
@@ -244,9 +214,12 @@ function main() {
   window.addEventListener('hashchange', handleHashChange);
 
   // ----------------------------------------------------------
-  const state = createProxy();
+  if (isRunningAsPWA) {
+    handleModalClose();
+  }
+  else if (!isIOS) {
+    let beforeInstallPromptFired = false;
 
-  if (!isIOS) {
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
@@ -254,12 +227,19 @@ function main() {
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
-      state.isInstalled = false;
+
+      beforeInstallPromptFired = true;
     });
+
+
+    if (!beforeInstallPromptFired) {
+      const installButton = document.getElementById('wepp-install-button');
+      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+      installButton.disabled = true;
+    }
   }
 
   window.addEventListener('appinstalled', () => {
-    state.isInstalled = true;
     console.log('PWA was installed');
   });
 }

--- a/fr/index.js
+++ b/fr/index.js
@@ -219,11 +219,11 @@ function main() {
   }
   else if (!isIOS) {
     let beforeInstallPromptFired = false;
+    const installButton = document.getElementById('wepp-install-button');
 
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
-      const installButton = document.getElementById('wepp-install-button');
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
@@ -231,12 +231,13 @@ function main() {
       beforeInstallPromptFired = true;
     });
 
-
-    if (!beforeInstallPromptFired) {
-      const installButton = document.getElementById('wepp-install-button');
-      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
-      installButton.disabled = true;
-    }
+    // Give the browser time to fire the beforeinstallprompt event
+    setTimeout(() => {
+      if (!beforeInstallPromptFired) {
+        installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+        installButton.disabled = true;
+      }
+    }, 1000); // 1 second delay
   }
 
   window.addEventListener('appinstalled', () => {

--- a/fr/index.js
+++ b/fr/index.js
@@ -17,6 +17,7 @@ const TEXT = {
   WAITING: 'Chargement des informations de l\'application...', // Loading app info...
   SKIP_BUTTON: 'Ça va, je préfère y accéder sur mon mobile.', // I'm fine, I'll just view it on my mobile.
   INSTALL_BUTTON: 'Installer comme application', // Install as an app
+  INSTALL_UNAVAILABLE: "L'application est déjà installée ou votre environnement ne prend pas en charge l'installation.", // The app is already installed or your environment doesn't support installation.
   // IOS device specific text
   IOS: {
     TITLE: 'Comment installer l\'application sur iOS', // IOS App Installation Method
@@ -118,40 +119,6 @@ function appendStyles() {
   document.head.appendChild(style);
 }
 
-/**
- * Create a Proxy object to detect whether PWA is installed
- */
-function createProxy() {
-  // 상태 객체
-  let state = {
-    isInstalled: true,
-  };
-
-  // Handlers for detecting state changes
-  const handler = {
-    set: function (target, property, value) {
-      // console.log(
-      //   `${property} changed from ${target[property]} to ${value}.`
-      // );
-      target[property] = value;
-      // Additional actions after status change
-      if (property === 'isInstalled') {
-        if (value) {
-          // console.log('PWA is already installed');
-        } else {
-          // console.log('PWA is not installed');
-        }
-      }
-      return true;
-    },
-  };
-
-  // Proxy
-  const proxyState = new Proxy(state, handler);
-
-  return proxyState;
-}
-
 const getModalContent = (isIOS) => {
   return isIOS ? IOS_MODAL_CONTENT : DEFAULT_MODAL_CONTENT;
 };
@@ -226,6 +193,9 @@ const showPrompt = (deferredPrompt) => {
 
 function main() {
   const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const isRunningAsPWA =
+    window.matchMedia('(display-mode: standalone)').matches
+    || window.navigator.standalone === true; // iOS
 
   appendStyles();
 
@@ -244,9 +214,12 @@ function main() {
   window.addEventListener('hashchange', handleHashChange);
 
   // ----------------------------------------------------------
-  const state = createProxy();
+  if (isRunningAsPWA) {
+    handleModalClose();
+  }
+  else if (!isIOS) {
+    let beforeInstallPromptFired = false;
 
-  if (!isIOS) {
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
@@ -254,12 +227,19 @@ function main() {
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
-      state.isInstalled = false;
+
+      beforeInstallPromptFired = true;
     });
+
+
+    if (!beforeInstallPromptFired) {
+      const installButton = document.getElementById('wepp-install-button');
+      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+      installButton.disabled = true;
+    }
   }
 
   window.addEventListener('appinstalled', () => {
-    state.isInstalled = true;
     console.log('PWA was installed');
   });
 }

--- a/index.js
+++ b/index.js
@@ -219,11 +219,11 @@ function main() {
   }
   else if (!isIOS) {
     let beforeInstallPromptFired = false;
+    const installButton = document.getElementById('wepp-install-button');
 
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
-      const installButton = document.getElementById('wepp-install-button');
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
@@ -231,12 +231,13 @@ function main() {
       beforeInstallPromptFired = true;
     });
 
-
-    if (!beforeInstallPromptFired) {
-      const installButton = document.getElementById('wepp-install-button');
-      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
-      installButton.disabled = true;
-    }
+    // Give the browser time to fire the beforeinstallprompt event
+    setTimeout(() => {
+      if (!beforeInstallPromptFired) {
+        installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+        installButton.disabled = true;
+      }
+    }, 1000); // 1 second delay
   }
 
   window.addEventListener('appinstalled', () => {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const TEXT = {
   WAITING: '앱 정보 불러오는 중...', // Loading app info...
   SKIP_BUTTON: '괜찮아요, 모바일 웹으로 볼게요.', // I'm fine, I'll just view it on my mobile.
   INSTALL_BUTTON: '앱 설치하기', // Install as an app
+  INSTALL_UNAVAILABLE: '이미 앱이 설치되어 있거나, 설치를 지원하지 않는 환경이에요.', // The app is already installed or your environment doesn't support installation.
   // IOS device specific text
   IOS: {
     TITLE: 'IOS 앱 설치 방법', // IOS App Installation Method
@@ -118,40 +119,6 @@ function appendStyles() {
   document.head.appendChild(style);
 }
 
-/**
- * Create a Proxy object to detect whether PWA is installed
- */
-function createProxy() {
-  // 상태 객체
-  let state = {
-    isInstalled: true,
-  };
-
-  // Handlers for detecting state changes
-  const handler = {
-    set: function (target, property, value) {
-      // console.log(
-      //   `${property} changed from ${target[property]} to ${value}.`
-      // );
-      target[property] = value;
-      // Additional actions after status change
-      if (property === 'isInstalled') {
-        if (value) {
-          // console.log('PWA is already installed');
-        } else {
-          // console.log('PWA is not installed');
-        }
-      }
-      return true;
-    },
-  };
-
-  // Proxy
-  const proxyState = new Proxy(state, handler);
-
-  return proxyState;
-}
-
 const getModalContent = (isIOS) => {
   return isIOS ? IOS_MODAL_CONTENT : DEFAULT_MODAL_CONTENT;
 };
@@ -226,6 +193,9 @@ const showPrompt = (deferredPrompt) => {
 
 function main() {
   const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const isRunningAsPWA =
+    window.matchMedia('(display-mode: standalone)').matches
+    || window.navigator.standalone === true; // iOS
 
   appendStyles();
 
@@ -244,9 +214,12 @@ function main() {
   window.addEventListener('hashchange', handleHashChange);
 
   // ----------------------------------------------------------
-  const state = createProxy();
+  if (isRunningAsPWA) {
+    handleModalClose();
+  }
+  else if (!isIOS) {
+    let beforeInstallPromptFired = false;
 
-  if (!isIOS) {
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
@@ -254,12 +227,19 @@ function main() {
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
-      state.isInstalled = false;
+
+      beforeInstallPromptFired = true;
     });
+
+
+    if (!beforeInstallPromptFired) {
+      const installButton = document.getElementById('wepp-install-button');
+      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+      installButton.disabled = true;
+    }
   }
 
   window.addEventListener('appinstalled', () => {
-    state.isInstalled = true;
     console.log('PWA was installed');
   });
 }

--- a/ko/index.js
+++ b/ko/index.js
@@ -219,11 +219,11 @@ function main() {
   }
   else if (!isIOS) {
     let beforeInstallPromptFired = false;
+    const installButton = document.getElementById('wepp-install-button');
 
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
-      const installButton = document.getElementById('wepp-install-button');
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
@@ -231,12 +231,13 @@ function main() {
       beforeInstallPromptFired = true;
     });
 
-
-    if (!beforeInstallPromptFired) {
-      const installButton = document.getElementById('wepp-install-button');
-      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
-      installButton.disabled = true;
-    }
+    // Give the browser time to fire the beforeinstallprompt event
+    setTimeout(() => {
+      if (!beforeInstallPromptFired) {
+        installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+        installButton.disabled = true;
+      }
+    }, 1000); // 1 second delay
   }
 
   window.addEventListener('appinstalled', () => {

--- a/ko/index.js
+++ b/ko/index.js
@@ -17,6 +17,7 @@ const TEXT = {
   WAITING: '앱 정보 불러오는 중...', // Loading app info...
   SKIP_BUTTON: '괜찮아요, 모바일 웹으로 볼게요.', // I'm fine, I'll just view it on my mobile.
   INSTALL_BUTTON: '앱 설치하기', // Install as an app
+  INSTALL_UNAVAILABLE: '이미 앱이 설치되어 있거나, 설치를 지원하지 않는 환경이에요.', // The app is already installed or your environment doesn't support installation.
   // IOS device specific text
   IOS: {
     TITLE: 'IOS 앱 설치 방법', // IOS App Installation Method
@@ -118,40 +119,6 @@ function appendStyles() {
   document.head.appendChild(style);
 }
 
-/**
- * Create a Proxy object to detect whether PWA is installed
- */
-function createProxy() {
-  // 상태 객체
-  let state = {
-    isInstalled: true,
-  };
-
-  // Handlers for detecting state changes
-  const handler = {
-    set: function (target, property, value) {
-      // console.log(
-      //   `${property} changed from ${target[property]} to ${value}.`
-      // );
-      target[property] = value;
-      // Additional actions after status change
-      if (property === 'isInstalled') {
-        if (value) {
-          // console.log('PWA is already installed');
-        } else {
-          // console.log('PWA is not installed');
-        }
-      }
-      return true;
-    },
-  };
-
-  // Proxy
-  const proxyState = new Proxy(state, handler);
-
-  return proxyState;
-}
-
 const getModalContent = (isIOS) => {
   return isIOS ? IOS_MODAL_CONTENT : DEFAULT_MODAL_CONTENT;
 };
@@ -226,6 +193,9 @@ const showPrompt = (deferredPrompt) => {
 
 function main() {
   const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const isRunningAsPWA =
+    window.matchMedia('(display-mode: standalone)').matches
+    || window.navigator.standalone === true; // iOS
 
   appendStyles();
 
@@ -244,9 +214,12 @@ function main() {
   window.addEventListener('hashchange', handleHashChange);
 
   // ----------------------------------------------------------
-  const state = createProxy();
+  if (isRunningAsPWA) {
+    handleModalClose();
+  }
+  else if (!isIOS) {
+    let beforeInstallPromptFired = false;
 
-  if (!isIOS) {
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       const deferredPrompt = e;
@@ -254,12 +227,19 @@ function main() {
       installButton.addEventListener('click', () => showPrompt(deferredPrompt), { once: true })
       installButton.innerText = TEXT.INSTALL_BUTTON;
       installButton.disabled = false;
-      state.isInstalled = false;
+
+      beforeInstallPromptFired = true;
     });
+
+
+    if (!beforeInstallPromptFired) {
+      const installButton = document.getElementById('wepp-install-button');
+      installButton.innerText = TEXT.INSTALL_UNAVAILABLE;
+      installButton.disabled = true;
+    }
   }
 
   window.addEventListener('appinstalled', () => {
-    state.isInstalled = true;
     console.log('PWA was installed');
   });
 }


### PR DESCRIPTION
### Description

This PR adds support for detecting whether the PWA can be installed and displays appropriate fallback messages if installation is not available.

### Changes

- Added `installAvailable` logic based on `beforeinstallprompt` and `display-mode`
- Added fallback messages: `INSTALL_UNAVAILABLE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added clear messaging when app installation is unavailable, including new fallback messages in multiple languages.
- **Bug Fixes**
	- Improved detection of PWA installation status and support, ensuring the install option is only shown when available.
- **Refactor**
	- Simplified installation state management by removing proxy-based tracking and using direct environment checks and event-driven UI updates.
- **Documentation**
	- Updated changelog to reflect recent changes and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->